### PR TITLE
Fix infinite recursion on Windows

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -216,7 +216,7 @@ class AutoConfig(object):
 
         # search the parent
         parent = os.path.dirname(path)
-        if parent and parent != os.path.abspath(os.sep):
+        if parent and os.path.normcase(parent) != os.path.normcase(os.path.abspath(os.sep)):
             return self._find_file(parent)
 
         # reached root without finding any files.

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -97,3 +97,13 @@ def test_autoconfig_env_default_encoding():
             assert config.encoding == DEFAULT_ENCODING
             assert 'ENV' == config('KEY', default='ENV')
             mopen.assert_called_once_with(filename, encoding=DEFAULT_ENCODING)
+
+
+def test_autoconfig_no_repository():
+    path = os.path.join(os.path.dirname(__file__), 'autoconfig', 'ini', 'no_repository')
+    config = AutoConfig(path)
+
+    with pytest.raises(UndefinedValueError):
+        config('KeyNotInEnvAndNotInRepository')
+
+    assert isinstance(config.config.repository, RepositoryEmpty)


### PR DESCRIPTION
On windows, when running using VSCode and using the integrated terminal to launch my application, _caller_path returns a path starting with c:\ (lowercase) while os.path.abspath(os.sep) return C:\ (uppercase). This causes infinite recursion in _find_file 