### PR TITLE
Adding typing for AutoConfig's __call__()

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -241,6 +241,47 @@ class AutoConfig(object):
         path = os.path.dirname(frame.f_back.f_back.f_code.co_filename)
         return path
 
+    if sys.version_info >= (3, 5, 0):
+        from typing import Callable, TypeVar, overload
+        _Def  = TypeVar('_Def')
+        _Cast = TypeVar('_Cast')
+
+        @overload
+        def __call__(
+            self,
+            option # type: str
+        ): # type: (...) -> str
+            ''''''
+            pass
+        @overload
+        def __call__(
+            self,
+            option, # type: str
+            default # type: _Def
+        ): # type: (...) -> str | _Def
+            ''''''
+            pass
+        @overload
+        def __call__(
+            self,
+            option, # type: str
+            cast # type: Callable[[str], _Cast]
+        ): # type: (...) -> _Cast
+            '''
+            `cast` has to be passed as a keyword argument for this usage,
+            otherwise, it will actually run as overload 2
+            '''
+            pass
+        @overload
+        def __call__(
+            self,
+            option,  # type: str
+            default, # type: _Def 
+            cast,    # type: Callable[[str | _Def], _Cast]
+        ): # type: (...) -> _Cast
+            ''''''
+            pass
+
     def __call__(self, *args, **kwargs):
         if not self.config:
             self._load(self.search_path or self._caller_path())

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tox==2.7.0
 docutils==0.14
 Pygments>=2.7.4
 twine
-virtualenv==20.21.1
+virtualenv<=20.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tox==2.7.0
 docutils==0.14
 Pygments>=2.7.4
 twine
+virtualenv==20.21.1


### PR DESCRIPTION
I added type hints and overloads for the `__call__` method of AutoConfig, which with some effort, I managed to do in a way that doesn't break Python2 support (I had to specify the `virtualenv` version to even test with python2, because they [dropped support for it on version 20.22.0](https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19), and some required package was downloading the latest version).

I could add typing for the rest of package, but doing it while working around Py2 is not really pleasant. I believe that this method alone (the `__call__` of AutoConfig, which is what everyone doing `from decouple import config` is using) represents ~80% of people's usage of this package, so I will limit myself to it.