### PR TITLE
Add Support for string as a Source

### DIFF
--- a/decouple.py
+++ b/decouple.py
@@ -188,6 +188,79 @@ class RepositorySecret(RepositoryEmpty):
         return self.data[key]
 
 
+class RepositoryString(RepositoryEmpty):
+    """
+    Repository class to retrieve options from a string.
+
+    Parses a string formatted like a `.env` file into a dictionary of options.
+    This class is an extension of the `RepositoryEmpty` class that provides a
+    way to read configuration keys from an environment string.
+
+    Attributes:
+        data (dict): A dictionary to hold the parsed key-value pairs.
+    """
+
+    def __init__(self, source):
+        """
+        Initializes the RepositoryString with a given string source.
+
+        The provided string should have one "KEY=value" pair per line, similar
+        to a `.env` file format. Lines starting with `#` are considered as
+        comments and ignored. Surrounding whitespace is stripped from keys
+        and values.
+
+        Args:
+            source (str): The string source to parse.
+        """
+        self.data = {}
+        source_lines = source.split('\n')
+
+        for line in source_lines:
+            line = line.strip()
+
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+
+            key, value = line.split('=', 1)
+            key = key.strip()
+            value = value.strip()
+
+            if len(value) >= 2 and (
+                (value[0] == "'" and value[-1] == "'")
+                or (value[0] == '"' and value[-1] == '"')
+            ):
+                value = value[1:-1]
+
+            self.data[key] = value
+
+    def __contains__(self, key):
+        """
+        Check if a key is present in the repository or the environment.
+
+        Args:
+            key (str): The key to check for presence.
+
+        Returns:
+            bool: True if key is in the repository or os.environ, False otherwise.
+        """
+        return key in os.environ or key in self.data
+
+    def __getitem__(self, key):
+        """
+        Retrieve the value associated with the given key.
+
+        Args:
+            key (str): The key to retrieve the value for.
+
+        Returns:
+            str: The value associated with the key.
+
+        Raises:
+            KeyError: If the key is not found in the repository.
+        """
+        return self.data[key]
+
+
 class AutoConfig(object):
     """
     Autodetects the config file and type.

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+import os
+import pytest
+from decouple import Config, RepositoryString, UndefinedValueError
+
+ENVSTRING = '''
+KeyTrue=True\nKeyOne=1\nKeyYes=yes
+KeyY=y
+KeyOn=on
+
+KeyFalse=False
+KeyZero=0
+KeyNo=no
+KeyN=n
+KeyOff=off
+KeyEmpty=
+
+# CommentedKey=None
+KeyWithSpaces = Some Value With Spaces
+KeyWithQuotes="Quoted Value"
+'''
+
+
+@pytest.fixture(scope='module')
+def config():
+    return Config(RepositoryString(ENVSTRING))
+
+
+def test_string_comment(config):
+    with pytest.raises(UndefinedValueError):
+        config('CommentedKey')
+
+
+def test_string_bool_true(config):
+    assert config('KeyTrue', cast=bool)
+    assert config('KeyOne', cast=bool)
+    assert config('KeyYes', cast=bool)
+    assert config('KeyY', cast=bool)
+    assert config('KeyOn', cast=bool)
+
+
+def test_string_bool_false(config):
+    assert not config('KeyFalse', cast=bool)
+    assert not config('KeyZero', cast=bool)
+    assert not config('KeyNo', cast=bool)
+    assert not config('KeyOff', cast=bool)
+    assert not config('KeyN', cast=bool)
+    assert not config('KeyEmpty', cast=bool)
+
+
+def test_string_undefined(config):
+    with pytest.raises(UndefinedValueError):
+        config('UndefinedKey')
+
+
+def test_string_default_none(config):
+    assert config('UndefinedKey', default=None) is None
+
+
+def test_string_default_bool(config):
+    assert not config('UndefinedKey', default=False, cast=bool)
+    assert config('UndefinedKey', default=True, cast=bool)
+
+
+def test_string_default(config):
+    assert not config('UndefinedKey', default=False)
+    assert config('UndefinedKey', default=True)
+
+
+def test_string_default_invalid_bool(config):
+    with pytest.raises(ValueError):
+        config('UndefinedKey', default='NotBool', cast=bool)
+
+
+def test_string_empty(config):
+    assert config('KeyEmpty', default=None) == ''
+
+
+def test_string_support_space(config):
+    assert config('KeyWithSpaces') == 'Some Value With Spaces'
+
+
+def test_string_os_environ(config):
+    os.environ['KeyOverrideByEnv'] = 'This'
+    assert config('KeyOverrideByEnv') == 'This'
+    del os.environ['KeyOverrideByEnv']
+
+
+def test_string_undefined_but_present_in_os_environ(config):
+    os.environ['KeyOnlyEnviron'] = ''
+    assert config('KeyOnlyEnviron') == ''
+    del os.environ['KeyOnlyEnviron']
+
+
+def test_string_empty_string_means_false(config):
+    assert not config('KeyEmpty', cast=bool)
+
+
+def test_string_repo_keyerror(config):
+    with pytest.raises(KeyError):
+        config.repository['UndefinedKey']
+
+
+def test_string_quoted_value(config):
+    assert config('KeyWithQuotes') == 'Quoted Value'


### PR DESCRIPTION
Original Credit: https://www.codingforentrepreneurs.com/blog/google-secrets-python-decouple-github-actions/

Working with Google Secret Manager, the config is provided back as a string. To support the format, a `RepositoryString` class has been created which parses a string in `.env` format.